### PR TITLE
Fix comment id char

### DIFF
--- a/hekate_ipl.ini
+++ b/hekate_ipl.ini
@@ -13,4 +13,4 @@ kip1=nx-dreport.kip
 [Thog,vgmoose,Adubbz,CTCaer]
 [WerWolv,thomasnet,Brawl]
 
-; This is meant to make it easier for us to help people in the #user-support on the ReSwitched Discord
+# This is meant to make it easier for us to help people in the #user-support on the ReSwitched Discord


### PR DESCRIPTION
Fix comment char from ; to #
Future versions, will support ini editing, in which, the previous char would be removed.

The previous char does not break anything currently.
It was added into [WerWolv,thomasnet,Brawl] entry and was rejected by the hos_launch code.